### PR TITLE
Add support for More Categories plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin can be installed via:
     python -m pip install pelican-neighbors
 
 
-## Basic usage
+## Usage
 
 This plugin adds a couple of new variables to the article's context:
 
@@ -20,6 +20,8 @@ This plugin adds a couple of new variables to the article's context:
 * `prev_article` (older)
 * `next_article_in_category`
 * `prev_article_in_category`
+* `next_article_in_subcategory#`
+* `prev_article_in_subcategory#`
 
 Here is an example on how to add article navigation in your Jinja `article.html`
 template:
@@ -59,11 +61,24 @@ template:
 </ul>
 ```
 
+## more_categories plugin support
+You can use `Neighbors` with the [`more_categories`](https://github.com/pelican-plugins/more-categories) plugin.
+
+Since an article can belong to more than one subcategory, subcategories are
+stored in a list. If you have an article with subcategories like
+`foo/bar/baz`, it will belong to both subcategory `bar`, and `bar/baz`.
+
+Subcategory neighbors are added to an article as `next_article_in_subcategory#`
+and `prev_article_in_subcategory#` where `#` is the level of subcategory.
+
+Using the example above:
+- `sebcategory0` is `foo`
+- `subcategory1` will be `foo/bar`
+- `subcategory2` will be `foo/bar/baz`
 
 ## Subcategory plugin support
 
-Following below are instructions on how to use `Neighbors` in conjunction with
-the [`Subcategory`
+You can use `Neighbors` in conjunction with the [`Subcategory`
 plugin](https://github.com/getpelican/pelican-plugins/tree/master/subcategory).
 
 Since an article can belong to more than one subcategory, subcategories are
@@ -75,7 +90,9 @@ and `prev_article_in_subcategory#` where `#` is the level of subcategory. So
 using the example from above, `subcategory1` will be `Foo`, and `subcategory2`
 will be `Foo/Bar`.
 
-Therefor the usage with subcategories is:
+## template examples
+
+The usage with subcategories from either `subcategory` or `more_categories` is:
 
 ```html+jinja
 <ul>

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Subcategory neighbors are added to an article as `next_article_in_subcategory#`
 and `prev_article_in_subcategory#` where `#` is the level of subcategory.
 
 Using the example above:
-- `sebcategory0` is `foo`
+- `subcategory0` is `foo`
 - `subcategory1` will be `foo/bar`
 - `subcategory2` will be `foo/bar/baz`
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ template:
 </ul>
 ```
 
-## more_categories plugin support
-You can use `Neighbors` with the [`more_categories`](https://github.com/pelican-plugins/more-categories) plugin.
+## More Categories plugin support
+
+You can use the `Neighbors` plugin with the [More
+Categories](https://github.com/pelican-plugins/more-categories) plugin.
 
 Since an article can belong to more than one subcategory, subcategories are
 stored in a list. If you have an article with subcategories like
@@ -78,7 +80,7 @@ Using the example above:
 
 ## Subcategory plugin support
 
-You can use `Neighbors` in conjunction with the [`Subcategory`
+You can use the Neighbors plugin in conjunction with the [Subcategory
 plugin](https://github.com/getpelican/pelican-plugins/tree/master/subcategory).
 
 Since an article can belong to more than one subcategory, subcategories are
@@ -90,9 +92,9 @@ and `prev_article_in_subcategory#` where `#` is the level of subcategory. So
 using the example from above, `subcategory1` will be `Foo`, and `subcategory2`
 will be `Foo/Bar`.
 
-## template examples
+## Template Examples
 
-The usage with subcategories from either `subcategory` or `more_categories` is:
+The usage with subcategories from either the Subcategory plugin or the More Categories plugin is:
 
 ```html+jinja
 <ul>
@@ -128,6 +130,10 @@ The usage with subcategories from either `subcategory` or `more_categories` is:
     {% endif %}
 </ul>
 ```
+
+## Limitations
+
+If an article has multiple categories, only the first category is considered.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ template:
 
 ## More Categories plugin support
 
-You can use the `Neighbors` plugin with the [More
+You can use the Neighbors plugin with the [More
 Categories](https://github.com/pelican-plugins/more-categories) plugin.
 
 Since an article can belong to more than one subcategory, subcategories are

--- a/pelican/plugins/neighbors/neighbors.py
+++ b/pelican/plugins/neighbors/neighbors.py
@@ -48,7 +48,7 @@ def neighbors(generator):
         articles.sort(key=lambda x: x.date, reverse=True)
         set_neighbors(articles, "next_article_in_category", "prev_article_in_category")
 
-    # support for more_categories plugin
+    # support for the More Categories plugin
     for category, articles in generator.categories:
         articles.sort(key=lambda x: x.date, reverse=True)
         index = category.name.count("/")
@@ -56,7 +56,7 @@ def neighbors(generator):
         prev_name = f"prev_article_in_subcategory{index}"
         set_neighbors(articles, next_name, prev_name)
 
-    # support for subcategory plugin
+    # support for the Subcategory Plugin
     if hasattr(generator, "subcategories"):
         for subcategory, articles in generator.subcategories:
             articles.sort(key=lambda x: x.date, reverse=True)

--- a/pelican/plugins/neighbors/neighbors.py
+++ b/pelican/plugins/neighbors/neighbors.py
@@ -48,6 +48,15 @@ def neighbors(generator):
         articles.sort(key=lambda x: x.date, reverse=True)
         set_neighbors(articles, "next_article_in_category", "prev_article_in_category")
 
+    # support for more_categories plugin
+    for category, articles in generator.categories:
+        articles.sort(key=lambda x: x.date, reverse=True)
+        index = category.name.count("/")
+        next_name = f"next_article_in_subcategory{index}"
+        prev_name = f"prev_article_in_subcategory{index}"
+        set_neighbors(articles, next_name, prev_name)
+
+    # support for subcategory plugin
     if hasattr(generator, "subcategories"):
         for subcategory, articles in generator.subcategories:
             articles.sort(key=lambda x: x.date, reverse=True)


### PR DESCRIPTION
This change adds support for the [More Categories][] plugin, allowing users to show neighbors based on a custom level of subcategory. It copies the approach used for the [Subcategory][] plugin.

It doesn't change the existing support for the [Subcategory][] plugin.

### Why is this necessary?

[More Categories][] offers support for subcategories and also multiple categories, whereas [Subcategory][] doesn't offer support for multiple categories.

Also, [Subcategory][] hasn't been updated recently and isn't in the new Pelican plugins directory. [More Categories][] is in the Pelican plugins organization. Therefore it seems preferable to support the [More Categories][] plugin in preference to the [Subcategory][] plugin.

### Limitations
If an article has multiple categories, only the first category is considered.

[More Categories]: https://github.com/pelican-plugins/more-categories
[Subcategory]: https://github.com/getpelican/pelican-plugins/tree/master/subcategory